### PR TITLE
Add Ecto.DateTime encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ You can use `phoenix_ecto` in your projects in two steps:
 
 This project:
 
-  * Implements the Phoenix.HTML.FormData protocol for Ecto.Changeset
-  * Implements the Phoenix.HTML.Safe protocol for Decimal
+  * Implements the `Phoenix.HTML.FormData` protocol for `Ecto.Changeset`
+  * Implements the `Phoenix.HTML.Safe` protocol for `Decimal`
+  * Implements the `Poison.Encoder` protocol for `Ecto.Date`, `Time` and
+    `DateTime`
 
 ## License
 

--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -15,7 +15,7 @@ if Code.ensure_loaded?(Phoenix.HTML) do
     defp form_for_name(%{__struct__: module}),
       do: Phoenix.Naming.resource_name(module)
 
-    defp form_for_method(%{__state__: :loaded}), do: "put"
+    defp form_for_method(%{__meta__: %{state: :loaded}}), do: "put"
     defp form_for_method(_), do: "post"
   end
 

--- a/lib/phoenix_ecto/json.ex
+++ b/lib/phoenix_ecto/json.ex
@@ -1,0 +1,11 @@
+defimpl Poison.Encoder, for: Ecto.Date do
+  def encode(date, _options), do: date |> Ecto.Date.to_iso8601
+end
+
+defimpl Poison.Encoder, for: Ecto.Time do
+  def encode(time, _options), do: time |> Ecto.Time.to_iso8601
+end
+
+defimpl Poison.Encoder, for: Ecto.DateTime do
+  def encode(date_time, _options), do: date_time |> Ecto.DateTime.to_iso8601
+end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,6 @@ defmodule PhoenixEcto.Mixfile do
     # primary key functions are changing in the
     # next release.
     [{:phoenix, "~> 0.10-dev"},
-     {:ecto, "~> 0.9.0"}]
+     {:ecto, github: "elixir-lang/ecto"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.9.0"},
+  "ecto": {:git, "git://github.com/elixir-lang/ecto.git", "2d3b51155acbdd6154c0f33bab198a0b20f5aec3", []},
   "phoenix": {:hex, :phoenix, "0.10.0"},
   "plug": {:hex, :plug, "0.11.1"},
   "poison": {:hex, :poison, "1.3.1"},

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -24,7 +24,7 @@ defmodule PhoenixEcto.HTMLTest do
     assert html_escape(d) == {:safe, "2010-04-17"}
 
     dt = %Ecto.DateTime{year: 2010, month: 4, day: 17, hour: 0, min: 0, sec: 0}
-    assert html_escape(dt) == {:safe, "2010-04-17T00:00:00Z"}
+    assert html_escape(dt) == {:safe, "2010-04-17 00:00:00"}
   end
 
   test "form_for/4 with new changeset" do
@@ -41,7 +41,7 @@ defmodule PhoenixEcto.HTMLTest do
   end
 
   test "form_for/4 with loaded changeset" do
-    changeset = Ecto.Changeset.cast(%User{__state__: :loaded, id: 13},
+    changeset = Ecto.Changeset.cast(%User{__meta__: %{state: :loaded}, id: 13},
                                     %{"foo" => "bar"}, ~w(), ~w())
 
     {:safe, form} = form_for(changeset, "/", fn f ->

--- a/test/phoenix_ecto/json_test.exs
+++ b/test/phoenix_ecto/json_test.exs
@@ -1,0 +1,14 @@
+defmodule PhoenixEcto.JSONTest do
+  use ExUnit.Case, async: true
+
+  test "encodes Ecto time structs" do
+    time = %Ecto.Time{hour: 0, min: 0, sec: 0}
+    assert Poison.encode!(time) == Ecto.Time.to_iso8601(time)
+
+    date = %Ecto.Date{year: 2010, month: 4, day: 17}
+    assert Poison.encode!(date) == Ecto.Date.to_iso8601(date)
+
+    dt = %Ecto.DateTime{year: 2010, month: 4, day: 17, hour: 0, min: 0, sec: 0}
+    assert Poison.encode!(dt) == Ecto.DateTime.to_iso8601(dt)
+  end
+end


### PR DESCRIPTION
Automatically encode Ecto.DateTime correctly when encoding JSON with Poison