### PR TITLE
Allow changeset errors to be a atoms

### DIFF
--- a/lib/phoenix_ecto/json.ex
+++ b/lib/phoenix_ecto/json.ex
@@ -22,7 +22,7 @@ if Code.ensure_loaded?(Poison) do
       end)
     end
 
-    defp json_error(msg) when is_binary(msg), do: msg
+    defp json_error(msg) when is_binary(msg) or is_atom(msg), do: msg
     defp json_error({msg, count}) when is_binary(msg) do
       String.replace(msg, "%{count}", Integer.to_string(count))
     end

--- a/test/phoenix_ecto/json_test.exs
+++ b/test/phoenix_ecto/json_test.exs
@@ -14,12 +14,12 @@ defmodule PhoenixEcto.JSONTest do
 
   test "encodes Ecto changeset errors" do
     changeset = %Ecto.Changeset{
-      errors: [name: "can't be blank", age: "is invalid",
+      errors: [name: "can't be blank", age: :invalid,
                name: "is taken", title: {"too long %{count}", 3}]
     }
 
     assert Poison.encode!(changeset) ==
-           ~s({"title":["too long 3"],"name":["can't be blank","is taken"],"age":["is invalid"]})
+           ~s({"title":["too long 3"],"name":["can't be blank","is taken"],"age":["invalid"]})
   end
 
   test "encodes decimal" do


### PR DESCRIPTION
According to https://github.com/elixir-lang/ecto/blob/master/lib/ecto/changeset.ex#L620, changeset errors can have atoms as values.

I'm also working on a PR for Ecto.Changeset to clarify the `@type error` which is too broad and not consistent with phoenix_ecto handling of them.