### PR TITLE
Supports serialization of Ecto.Changeset in v0.14.0

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -36,7 +36,7 @@ if Code.ensure_loaded?(Phoenix.HTML) do
     end
 
     defp form_for_error(msg) when is_binary(msg), do: msg
-    defp form_for_error({msg, count}) when is_binary(msg) do
+    defp form_for_error({msg, count: count}) when is_binary(msg) do
       String.replace(msg, "%{count}", Integer.to_string(count))
     end
 

--- a/lib/phoenix_ecto/json.ex
+++ b/lib/phoenix_ecto/json.ex
@@ -23,7 +23,7 @@ if Code.ensure_loaded?(Poison) do
     end
 
     defp json_error(msg) when is_binary(msg), do: msg
-    defp json_error({msg, count}) when is_binary(msg) do
+    defp json_error({msg, count: count}) when is_binary(msg) do
       String.replace(msg, "%{count}", Integer.to_string(count))
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,6 @@ defmodule PhoenixEcto.Mixfile do
   defp deps do
     [{:phoenix_html, "~> 1.0", optional: true},
      {:poison, "~> 1.3", optional: true},
-     {:ecto, "~> 0.12"}]
+     {:ecto, "~> 0.14"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.12.0"},
+  "ecto": {:hex, :ecto, "0.14.2"},
   "phoenix_html": {:hex, :phoenix_html, "1.0.0"},
   "plug": {:hex, :plug, "0.12.2"},
   "poison": {:hex, :poison, "1.4.0"},

--- a/test/phoenix_ecto/json_test.exs
+++ b/test/phoenix_ecto/json_test.exs
@@ -15,7 +15,7 @@ defmodule PhoenixEcto.JSONTest do
   test "encodes Ecto changeset errors" do
     changeset = %Ecto.Changeset{
       errors: [name: "can't be blank", age: "is invalid",
-               name: "is taken", title: {"too long %{count}", 3}]
+               name: "is taken", title: {"too long %{count}", count: 3}]
     }
 
     assert Poison.encode!(changeset) ==


### PR DESCRIPTION
> Ecto.Changeset.errors now return {"must be less than %{count}", count: 3} instead of {"must be less than %{count}", 3}