### PR TITLE
Bubble up relation errors to top-level form's errors

### DIFF
--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -74,13 +74,14 @@ defmodule PhoenixEcto.HTMLTest do
   test "form_for/4 with errors" do
     changeset =
       %User{}
-      |> cast(%{"name" => "JV"}, ~w(name), ~w())
+      |> cast(%{"name" => "JV", "comment" => %{"body" => "Yo"}}, ~w(name comment), ~w())
       |> validate_length(:name, min: 3)
       |> add_error(:score, {"must be greater than %{count}", count: Decimal.new(18)})
 
     form = safe_to_string(form_for(changeset, "/", [name: "another", multipart: true], fn f ->
       assert f.errors == [score: "must be greater than 18",
-                          name: "should be at least 3 characters"]
+                          name: "should be at least 3 characters",
+                          comment_body: "should be at least 3 characters"]
       "FROM FORM"
     end))
 


### PR DESCRIPTION
Form errors for relations do not show up in top-level form struct. It would be convenient if they did. This PR addresses that. 

This was the least intrusive I could think of. We could also bubble-up the errors from the nested changesets to the parent changeset in Ecto, if that makes more sense. Let me know if you prefer that approach and I would gladly make a PR for that.

Cheers!