### PR TITLE
Update ecto

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,6 @@ defmodule PhoenixEcto.Mixfile do
   defp deps do
     [{:phoenix_html, "~> 2.2", optional: true},
      {:poison, "~> 1.3", optional: true},
-     {:ecto, "~> 1.0"}]
+     {:ecto, "~> 1.0.7"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "1.0.1"},
+  "ecto": {:hex, :ecto, "1.0.7"},
   "phoenix_html": {:hex, :phoenix_html, "2.2.0"},
   "plug": {:hex, :plug, "1.0.0"},
   "poison": {:hex, :poison, "1.5.0"},


### PR DESCRIPTION
motivation is to address conflicting requirements on postgrex;
echo v1.0.6 requires postgrex ~> 0.9.1, while the latest postgrex is v0.10
