### PR TITLE
In ecto v1.0.3, Changeset.Relation on_replace/2 breaks tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,6 @@ defmodule PhoenixEcto.Mixfile do
   defp deps do
     [{:phoenix_html, "~> 2.2", optional: true},
      {:poison, "~> 1.3", optional: true},
-     {:ecto, "~> 1.0"}]
+     {:ecto, "~> 1.0.3"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "1.0.1"},
+  "ecto": {:hex, :ecto, "1.0.7"},
   "phoenix_html": {:hex, :phoenix_html, "2.2.0"},
   "plug": {:hex, :plug, "1.0.0"},
   "poison": {:hex, :poison, "1.5.0"},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,10 +36,10 @@ defmodule User do
     field :title
     field :age, :integer
     field :score, :decimal
-    embeds_one :permalink, Permalink
-    embeds_many :permalinks, Permalink
-    has_one :comment, Comment
-    has_many :comments, Comment
+    embeds_one :permalink, Permalink, on_replace: :delete
+    embeds_many :permalinks, Permalink, on_replace: :delete
+    has_one :comment, Comment, on_replace: :delete
+    has_many :comments, Comment, on_replace: :delete
   end
 end
 


### PR DESCRIPTION
ecto commit e880c8d on Sep 15 added @on_replace_opts :raise and :mark_as_invalid;
from ecto v1.0.3 onward, Changeset.Relation on_replace/2 breaks tests in HTMLTest

this branch modifies the test helper, specifically in User schema to add "on_replace: :delete" for the "embeds_" and "has_" calls
  