### PR TITLE
Relax poison requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule PhoenixEcto.Mixfile do
 
   defp deps do
     [{:phoenix_html, "~> 2.2", optional: true},
-     {:poison, "~> 1.3", optional: true},
+     {:poison, "~> 1.5 or ~> 2.0", optional: true},
      {:ecto, "~> 1.1.2 or ~> 2.0-dev"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "ecto": {:hex, :ecto, "1.1.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.2.0"},
   "plug": {:hex, :plug, "1.0.0"},
-  "poison": {:hex, :poison, "1.5.0"},
+  "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"}}


### PR DESCRIPTION
So that you can use 2.x in Phoenix project.