### PR TITLE
Adds Phoenix.Ecto.SQL.Sandbox plug

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -1,0 +1,75 @@
+defmodule Phoenix.Ecto.SQL.Sandbox do
+  @moduledoc """
+  A plug to allow concurrent, transactional acceptance tests with Ecto.Adapters.SQL.Sandbox.
+
+  ## Example
+
+  This plug should only be used during tests. First, set a flag to
+  enable it in `config/test.exs`:
+
+      config :my_app, sql_sandbox: true
+
+  And use the flag to conditionally add the plug to `lib/my_app/endpoint.ex`:
+
+      if Application.get_env(:my_app, :sql_sandbox) do
+        plug Phoenix.Ecto.SQL.Sandbox
+      end
+
+  Then, within an acceptance test, checkout a sandboxed connection as before.
+  Before starting the test, access the endpoint at `path_for/2`. This sets a cookie
+  that will be used on subsequent requests to allow access to the test's connection.
+  Here's an example using hound:
+
+      setup do
+        :ok = Ecto.Adapters.SQL.Sandbox.checkout(MyApp.Repo)
+        Hound.start_session
+        Hound.Helpers.Navigation.navigate_to Phoenix.Ecto.SQL.Sandbox.path_for(MyApp.Repo, self())
+      end
+  """
+
+  import Plug.Conn
+
+  @config_path "/phoenix/ecto/sql/sandbox/"
+  @cookie_name "phoenix.ecto.sql.sandbox"
+
+  def init(opts \\ []) do
+    Keyword.get(opts, :sandbox, Ecto.Adapters.SQL.Sandbox)
+  end
+
+  def call(%{request_path: @config_path <> configuration} = conn, _sandbox) do
+    conn |> put_resp_cookie(@cookie_name, configuration) |> send_resp(200, "OK") |> halt
+  end
+
+  def call(conn, sandbox) do
+    conn |> fetch_cookies |> allow_sandbox_access(sandbox)
+  end
+
+  @doc """
+  Returns the path to set the connection ownership cookie.
+
+  Sending this cookie in subsequent requests will allow
+  the endpoint to access the database connection checked
+  out by the test process.
+  """
+  @spec path_for(Ecto.Repo.t | [Ecto.Repo.t], pid) :: String.t
+  def path_for(repo_or_repos, pid) when is_pid(pid) do
+    repos = repo_or_repos |> List.wrap |> Enum.map_join("|", &Atom.to_string/1)
+    "#{@config_path}#{:erlang.pid_to_list(pid)}|#{repos}"
+  end
+
+  defp allow_sandbox_access(%{req_cookies: %{@cookie_name => configuration}} = conn, sandbox) do
+    [pid_string|repo_strings] = configuration |> URI.decode |> String.split("|")
+
+    owner = to_pid(pid_string)
+    repos = Enum.map(repo_strings, &String.to_atom/1)
+
+    Enum.each(repos, &sandbox.allow(&1, owner, self()))
+
+    conn
+  end
+  defp allow_sandbox_access(conn, _sandbox), do: conn
+
+  defp to_pid(string) do
+    string |> String.to_char_list |> :erlang.list_to_pid
+  end
+end

--- a/test/phoenix_ecto/sql/sandbox_test.exs
+++ b/test/phoenix_ecto/sql/sandbox_test.exs
@@ -1,0 +1,38 @@
+defmodule PhoenixEcto.SQL.SandboxTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Phoenix.Ecto.SQL.Sandbox
+
+  defmodule MockSandbox do
+    def allow(repo, owner, _allowed) do
+      send owner, {:allowed, repo}
+    end
+  end
+
+  defp call_plug(conn) do
+    opts = Sandbox.init(sandbox: MockSandbox)
+    Sandbox.call(conn, opts)
+  end
+
+  test "allows sandbox access to subsequent connections with proper cookie" do
+    old_conn = conn(:get, Sandbox.path_for(MyRepo, self())) |> call_plug
+    _conn = recycle_cookies(conn(:get, "/"), old_conn) |> call_plug
+
+    assert_receive {:allowed, MyRepo}
+  end
+
+  test "allows sandbox access to multiple repositories" do
+    old_conn = conn(:get, Sandbox.path_for([MyRepoOne, MyRepoTwo], self())) |> call_plug
+    _conn = recycle_cookies(conn(:get, "/"), old_conn) |> call_plug
+
+    assert_receive {:allowed, MyRepoOne}
+    assert_receive {:allowed, MyRepoTwo}
+  end
+
+  test "does not allow sandbox access without cookie" do
+    conn(:get, "/") |> call_plug
+
+    refute_receive {:allowed, _}
+  end
+end


### PR DESCRIPTION
This allows an acceptance test to allow a Plug connection
to access a sandboxed connection, enabling asynchronous
acceptance tests.

One question: Is there a way to do this without using cookies? @josevalim pointed out that phantomjs shares a cookie store between all sessions.

Closes elixir-lang/ecto#1237