### PR TITLE
Add support for maps as data in changesets

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -231,16 +231,20 @@ if Code.ensure_loaded?(Phoenix.HTML) do
     defp form_for_errors(%{action: nil}), do: []
     defp form_for_errors(%{errors: errors}), do: errors
 
-    defp form_for_hidden(data) do
+    defp form_for_hidden(%{__struct__: _} = data) do
       # Since they are primary keys, we should ignore nil values.
       for {k, v} <- Ecto.primary_key(data), v != nil, do: {k, v}
     end
+    defp form_for_hidden(_), do: []
 
     defp form_for_name(%{__struct__: module}) do
       module
       |> Module.split()
       |> List.last()
       |> Macro.underscore()
+    end
+    defp form_for_name(_) do
+      raise ArgumentError, "non-struct data passed in the changeset without `:as` option set"
     end
 
     defp form_for_method(%{__meta__: %{state: :loaded}}), do: "put"

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -110,6 +110,16 @@ defmodule PhoenixEcto.HTMLTest do
     assert form =~ ~s(<input id="another_other" name="another[other]" type="text">)
   end
 
+  test "form_for/4 with a map for changeset data" do
+    changeset = cast({%{}, %{name: :string}}, %{"name" => "JV"}, ~w(name))
+
+    form = safe_form_for(changeset, [as: "some"], fn f ->
+      [text_input(f, :name)]
+    end)
+
+    assert form =~ ~s(<input id="some_name" name="some[name]" type="text" value="JV">)
+  end
+
   defmodule Custom do
     use Ecto.Schema
 


### PR DESCRIPTION
Ecto supports passing `{data, types}` tuples for data, in addition to structs with schemas. Unfortunately, `phoenix_ecto` still assumes the data to be strictly a struct with a schema. This PR adds support for maps ~~and plain structs (without schema)~~ as data.

~~I'm not sure if https://github.com/phoenixframework/phoenix_ecto/pull/60/files#diff-5bbd15e070110d8f9b8d58d299755cf1R235 is the best way to tell apart a struct with schema from the one without but couldn't think of anything better at the moment.~~

**EDIT:** removed plain struct support - too questionable