### PR TITLE
Support 'pattern' input validation

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -163,6 +163,10 @@ if Code.ensure_loaded?(Phoenix.HTML) do
       step_for(type) ++ min_for(type, opts) ++ max_for(type, opts)
     end
 
+    defp validation_to_attrs({:format, opts}, _field, _changeset) do
+      [pattern: Regex.source(opts)]
+    end
+
     defp validation_to_attrs(_validation, _field, _changeset) do
       []
     end

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -158,12 +158,13 @@ defmodule PhoenixEcto.HTMLTest do
       |> validate_number(:integer, greater_than: 0, less_than: 100)
       |> validate_number(:float, greater_than_or_equal_to: 0)
       |> validate_length(:string, min: 0, max: 100)
+      |> validate_format(:string, ~r/.+@.+/)
 
     safe_form_for(changeset, fn f ->
       assert input_validations(f, :integer) == [required: true, step: 1, min: 1, max: 99]
       assert input_validations(f, :float)   == [required: false, step: "any", min: 0]
       assert input_validations(f, :decimal) == [required: false]
-      assert input_validations(f, :string)  == [required: true, maxlength: 100, minlength: 0]
+      assert input_validations(f, :string)  == [required: true, pattern: ".+@.+", maxlength: 100, minlength: 0]
       ""
     end)
   end


### PR DESCRIPTION
Adds support for the `pattern` input validation to match against a regex.

Corresponds to [validate_format/4](https://hexdocs.pm/ecto/Ecto.Changeset.html#validate_format/4).

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-pattern