### PR TITLE
Allow Plug.Exception implementations to not be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Thanks to Elixir protocols, the integration between Phoenix and Ecto is simply a
   * `Phoenix.HTML.Safe` protocol for `Decimal`, `Ecto.Date`, `Ecto.Time` and `Ecto.DateTime`
   * `Plug.Exception` protocol for the relevant Ecto exceptions
 
+## Configuration
+
+The `Plug.Exception` implementations for Ecto exceptions may be disabled by including the error in the mix configuration.
+
+```elixir
+config :phoenix_ecto,
+  exclude_ecto_exceptions_from_plug: [Ecto.NoResultsError]
+```
+
 ## License
 
 Same license as Phoenix.

--- a/lib/phoenix_ecto/plug.ex
+++ b/lib/phoenix_ecto/plug.ex
@@ -1,15 +1,16 @@
-defimpl Plug.Exception, for: Ecto.CastError do
-  def status(_), do: 400
-end
+errors = [
+  {Ecto.CastError, 400},
+  {Ecto.Query.CastError, 400},
+  {Ecto.NoResultsError, 404},
+  {Ecto.InvalidChangesetError, 422},
+]
 
-defimpl Plug.Exception, for: Ecto.Query.CastError do
-  def status(_), do: 400
-end
+excluded_exceptions = Application.get_env(:phoenix_ecto, :exclude_ecto_exceptions_from_plug, [])
 
-defimpl Plug.Exception, for: Ecto.NoResultsError do
-  def status(_), do: 404
-end
-
-defimpl Plug.Exception, for: Ecto.InvalidChangesetError do
-  def status(_), do: 422
+for {exception, status_code} <- errors do
+  unless exception in excluded_exceptions do
+    defimpl Plug.Exception, for: exception do
+      def status(_), do: unquote(status_code)
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,10 @@ defmodule PhoenixEcto.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :ecto, :plug]]
+    [
+      applications: [:logger, :ecto, :plug],
+      env: [exclude_ecto_exceptions_from_plug: []]
+    ]
   end
 
   defp package do


### PR DESCRIPTION
This will allow users to write alternate implementations or
treat them as unhandled exceptions.

Does not change behaviour unless explicitly configured to
do so.

Fixes https://github.com/phoenixframework/phoenix_ecto/issues/86