### PR TITLE
:normal formatting for Decimals

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -273,7 +273,7 @@ if Code.ensure_loaded?(Phoenix.HTML) do
 
   defimpl Phoenix.HTML.Safe, for: Decimal do
     def to_iodata(t) do
-      @for.to_string(t)
+      @for.to_string(t, :normal)
     end
   end
 

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -144,6 +144,16 @@ defmodule PhoenixEcto.HTMLTest do
     assert form =~ ~s(<input id="some_name" name="some[name]" type="text" value="JV">)
   end
 
+  test "form_for/4 with Decimal type input field" do
+    changeset = cast({%{}, %{price: :decimal}}, %{"price" => Decimal.new("0.000000000")}, ~w(price))
+
+    form = safe_form_for(changeset, [as: "some"], fn f ->
+      [number_input(f, :price)]
+    end)
+
+    assert form =~ ~s(<input id="some_price" name="some[price]" type="number" value="0.000000000">)
+  end
+
   defmodule Custom do
     use Ecto.Schema
 


### PR DESCRIPTION
I'm not sure if this is valid for everyone, but I don't see a point why it shouldn't be. The problem is with input fields for decimals which are formatted usually like this: `0E-10` (`:scientific` way). In my opinion more user friendly (for inputs) is a `:normal` formatting hence the change.