### PR TITLE
Ignore errors in case changeset action is :ignore.

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -246,6 +246,7 @@ if Code.ensure_loaded?(Phoenix.HTML) do
     end
 
     defp form_for_errors(%{action: nil}), do: []
+    defp form_for_errors(%{action: :ignore}), do: []
     defp form_for_errors(%{errors: errors}), do: errors
 
     defp form_for_hidden(%{__struct__: module} = data) do

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -89,6 +89,13 @@ defmodule PhoenixEcto.HTMLTest do
       "FROM FORM"
     end)
 
+    changeset = %{changeset | action: :ignore}
+
+    safe_form_for(changeset, [as: "another", multipart: true], fn f ->
+      assert f.errors == []
+      "FROM FORM"
+    end)
+
     changeset = %{changeset | action: :insert}
 
     form = safe_form_for(changeset, [as: "another", multipart: true], fn f ->


### PR DESCRIPTION
Hi
I've been trying to use `:ignore` action in changeset as described in [cast_assoc/3](https://hexdocs.pm/ecto/Ecto.Changeset.html#cast_assoc/3), e.g 

> Let’s suppose that, if one of the associations has only empty fields, you want to ignore the entry altogether instead of showing an error...

and noticed that phoenix form doesn't account for this case: it ignores errors only if changeset action is `nil` (hence `ErrorHelpers.error_tag/2`, generated in new phx project, will show these errors).

Is it possible to ignore errors in this case? Or maybe there's another accepted way to handle it?