### PR TITLE
Extract and translate internal exception from Ecto.SubQueryError

### DIFF
--- a/lib/phoenix_ecto/plug.ex
+++ b/lib/phoenix_ecto/plug.ex
@@ -14,3 +14,11 @@ for {exception, status_code} <- errors do
     end
   end
 end
+
+unless Ecto.SubQueryError in excluded_exceptions do
+  defimpl Plug.Exception, for: Ecto.SubQueryError do
+    def status(sub_query_error) do
+      Plug.Exception.status(sub_query_error.exception)
+    end
+  end
+end


### PR DESCRIPTION
This PR enables bad casts in subqueries to return 400 error code like in normal queries