### PR TITLE
Fix typo in start_child example doc

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -62,7 +62,7 @@ defmodule Phoenix.Ecto.SQL.Sandbox do
 
   ## Examples
 
-      iex> {:ok, _owner_pid, metdata} = start_child(MyApp.Repo)
+      iex> {:ok, _owner_pid, metadata} = start_child(MyApp.Repo)
   """
   def start_child(repo, opts \\ []) do
     case Supervisor.start_child(SandboxSupervisor, [repo, self(), opts]) do


### PR DESCRIPTION
Noticed a tiny typo in the example code :)