### PR TITLE
Add missing :ok in hound example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ setup do
   :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
   metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
   Hound.start_session(metadata: metadata)
+  :ok
 end
 ```
 

--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -29,6 +29,7 @@ defmodule Phoenix.Ecto.SQL.Sandbox do
         :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
         metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
         Hound.start_session(metadata: metadata)
+        :ok
       end
 
   ## Concurrent end-to-end tests with external clients


### PR DESCRIPTION
Hey there,

I was working with the documents on using hound + ecto sandbox and ran into an issue of not adding a `:ok` at the end of the `setup` block. 

I didn't realize that the `Hound.start_session` doesn't output an :ok. I believe modify the README like this can make it clearer for the next person :)