### PR TITLE
Add plug which checks for database creation and pending migrations

### DIFF
--- a/lib/phoenix_ecto/check_repo_status.ex
+++ b/lib/phoenix_ecto/check_repo_status.ex
@@ -1,0 +1,72 @@
+defmodule Phoenix.Ecto.CheckRepoStatus do
+  @moduledoc """
+  A plug that does some checks on your application repos.
+
+  Checks if the storage is up (database is created) or if there are any pending migrations.
+  Both checks can raise an error if the conditions are not met.
+
+  ## Plug options
+
+    * `:otp_app` - name of the application which the repos are fetched from
+    * `:get_migration_function` - function that returns the migrations for a given `repo`.
+      Should return a list of tuples with three elements,
+      e.g. `[{state :: :up | :down, version :: integer(), name :: String.t()]]`
+      If `ecto_sql` dependency is loaded, uses `Ecto.Migrator.migrations/1` by default.
+  """
+
+  @behaviour Plug
+
+  alias Plug.Conn
+
+  def init(opts) do
+    Keyword.fetch!(opts, :otp_app)
+    opts
+  end
+
+  def call(%Conn{} = conn, opts) do
+    repos = Application.get_env(opts[:otp_app], :ecto_repos, [])
+
+    for repo <- repos, Process.whereis(repo) do
+      check_storage_up!(repo)
+      check_pending_migrations!(repo, opts)
+    end
+
+    conn
+  end
+
+  defp check_storage_up!(repo) do
+    try do
+      if Code.ensure_loaded?(repo.__adapter__) &&
+           function_exported?(repo.__adapter__, :storage_status, 1) do
+        repo.__adapter__.storage_status(repo.config())
+      end
+    rescue
+      _ -> :ok
+    else
+      :down -> raise Phoenix.Ecto.StorageNotCreatedError, repo: repo
+      _ -> :ok
+    end
+  end
+
+  defp check_pending_migrations!(repo, opts) do
+    try do
+      # If the dependency `ecto_sql` is not loaded we can't check if
+      # there are pending migrations so we try to fail gracefully here
+      fallback_get_migrations =
+        if Code.ensure_loaded?(Ecto.Migrator),
+          do: &Ecto.Migrator.migrations/1,
+          else: fn _repo -> [] end
+
+      get_migrations = Keyword.get(opts, :get_migrations_function, fallback_get_migrations)
+
+      repo
+      |> get_migrations.()
+      |> Enum.any?(fn {status, _version, _migration} -> status == :down end)
+    rescue
+      _ -> :ok
+    else
+      true -> raise Phoenix.Ecto.PendingMigrationError, repo: repo
+      false -> :ok
+    end
+  end
+end

--- a/lib/phoenix_ecto/exceptions.ex
+++ b/lib/phoenix_ecto/exceptions.ex
@@ -1,0 +1,13 @@
+defmodule Phoenix.Ecto.StorageNotCreatedError do
+  defexception [:repo]
+
+  def message(%__MODULE__{repo: repo}),
+    do: "The storage is not created for repo: `#{inspect(repo)}`. Try `mix ecto.create`"
+end
+
+defmodule Phoenix.Ecto.PendingMigrationError do
+  defexception [:repo]
+
+  def message(%__MODULE__{repo: repo}),
+    do: "There are pending migrations for repo: `#{inspect(repo)}`. Try `mix ecto.migrate`"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,12 @@ defmodule PhoenixEcto.Mixfile do
         extras: ["README.md": [filename: "main", title: "Phoenix/Ecto"]],
         source_ref: "v#{@version}",
         source_url: "https://github.com/phoenixframework/phoenix_ecto"
+      ],
+      xref: [
+        exclude: [
+          {Ecto.Migrator, :migrations, 1},
+          {Ecto.Migrator, :run, 3}
+        ]
       ]
     ]
   end

--- a/test/phoenix_ecto/check_repo_status_test.exs
+++ b/test/phoenix_ecto/check_repo_status_test.exs
@@ -1,0 +1,209 @@
+defmodule Phoenix.Ecto.CheckRepoStatusTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Phoenix.Ecto.CheckRepoStatus
+
+  defmodule LongLivedProcess do
+    def run do
+      Process.sleep(1_000)
+      run()
+    end
+  end
+
+  defmodule StorageUpRepo do
+    defmodule Adapter, do: def(storage_status(_repo_config), do: :up)
+    def config, do: []
+    def __adapter__, do: Adapter
+  end
+
+  defmodule StorageDownRepo do
+    defmodule Adapter, do: def(storage_status(_repo_config), do: :down)
+    def config, do: []
+    def __adapter__, do: Adapter
+  end
+
+  defmodule NoStorageStatusRepo do
+    defmodule Adapter, do: nil
+    def config, do: []
+    def __adapter__, do: Adapter
+  end
+
+  defmodule StorageErrorRepo do
+    defmodule Adapter,
+      do: def(storage_status(_repo_config), do: {:error, %{message: "Adapter error"}})
+
+    def config, do: []
+    def __adapter__, do: Adapter
+  end
+
+  test "does not raise an error when the storage is created and there are no pending migrations for a repo" do
+    Process.register(self(), StorageUpRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageUpRepo])
+    get_migrations_function = fn _repo -> [] end
+
+    conn = conn(:get, "/")
+
+    assert conn ==
+             CheckRepoStatus.call(
+               conn,
+               otp_app: :check_repo_ready,
+               get_migrations_function: get_migrations_function
+             )
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageUpRepo)
+  end
+
+  test "raises an error when there is no storage created for a repo" do
+    Process.register(self(), StorageDownRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageDownRepo])
+    get_migrations_function = fn _repo -> [] end
+
+    conn = conn(:get, "/")
+
+    assert_raise(Phoenix.Ecto.StorageNotCreatedError, fn ->
+      CheckRepoStatus.call(
+        conn,
+        otp_app: :check_repo_ready,
+        get_migrations_function: get_migrations_function
+      )
+    end)
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageDownRepo)
+  end
+
+  test "raises an error when there are pending migrations for any repo" do
+    Process.register(self(), StorageUpRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageUpRepo])
+    get_migrations_function = fn _repo -> [{:down, 1, "migration"}] end
+
+    conn = conn(:get, "/")
+
+    assert_raise(Phoenix.Ecto.PendingMigrationError, fn ->
+      CheckRepoStatus.call(
+        conn,
+        otp_app: :check_repo_ready,
+        get_migrations_function: get_migrations_function
+      )
+    end)
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageUpRepo)
+  end
+
+  test "does not raise an error when the repo's adapter does not implement storage_status/1" do
+    Process.register(self(), StorageStatusRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [NoStorageStatusRepo])
+    get_migrations_function = fn _repo -> [] end
+
+    conn = conn(:get, "/")
+
+    assert conn ==
+             CheckRepoStatus.call(conn,
+               otp_app: :check_repo_ready,
+               get_migrations_function: get_migrations_function
+             )
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageStatusRepo)
+  end
+
+  test "does not raise an error when using the fallback get_migration_function" do
+    Process.register(self(), StorageUpRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageUpRepo])
+
+    conn = conn(:get, "/")
+
+    assert conn == CheckRepoStatus.call(conn, otp_app: :check_repo_ready)
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageUpRepo)
+  end
+
+  test "does not raise an error when storage_status returns {:error, term()}" do
+    Process.register(self(), StorageErrorRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageErrorRepo])
+    get_migrations_function = fn _repo -> [] end
+
+    conn = conn(:get, "/")
+
+    assert conn ==
+             CheckRepoStatus.call(conn,
+               otp_app: :check_repo_ready,
+               get_migrations_function: get_migrations_function
+             )
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageErrorRepo)
+  end
+
+  test "does not raise an error when the storage is created and there are no pending migrations for multiple repos" do
+    Process.register(self(), StorageUpRepo)
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageUpRepo, StorageUpRepo])
+
+    get_migrations_function = fn _repo -> [] end
+
+    conn = conn(:get, "/")
+
+    assert conn ==
+             CheckRepoStatus.call(
+               conn,
+               otp_app: :check_repo_ready,
+               get_migrations_function: get_migrations_function
+             )
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageUpRepo)
+  end
+
+  test "raises an error when one of multiple repos does not have the database created" do
+    Process.register(self(), StorageUpRepo)
+    Process.register(spawn_link(&LongLivedProcess.run/0), StorageDownRepo)
+
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageUpRepo, StorageDownRepo])
+
+    get_migrations_function = fn _repo -> [] end
+
+    conn = conn(:get, "/")
+
+    assert_raise(Phoenix.Ecto.StorageNotCreatedError, fn ->
+      CheckRepoStatus.call(
+        conn,
+        otp_app: :check_repo_ready,
+        get_migrations_function: get_migrations_function
+      )
+    end)
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageUpRepo)
+    Process.unregister(StorageDownRepo)
+  end
+
+  test "raises an error when one of multiple repos has pending migrations" do
+    Process.register(self(), StorageUpRepo)
+    Process.register(spawn_link(&LongLivedProcess.run/0), NoStorageStatusRepo)
+
+    Application.put_env(:check_repo_ready, :ecto_repos, [StorageUpRepo, NoStorageStatusRepo])
+
+    get_migrations_function = fn
+      StorageUpRepo -> []
+      NoStorageStatusRepo -> [{:down, 1, "migration"}]
+    end
+
+    conn = conn(:get, "/")
+
+    assert_raise(Phoenix.Ecto.PendingMigrationError, fn ->
+      CheckRepoStatus.call(
+        conn,
+        otp_app: :check_repo_ready,
+        get_migrations_function: get_migrations_function
+      )
+    end)
+  after
+    Application.delete_env(:check_repo_ready, :ecto_repos)
+    Process.unregister(StorageUpRepo)
+    Process.unregister(NoStorageStatusRepo)
+  end
+end


### PR DESCRIPTION
Works on top of elixir-plug/plug#876 and elixir-ecto/ecto_sql#164 to provide a Plug that raises an error if at least one of the repos defined in `Application.get_env(:otp_app, :ecto_repos)` does not have the storage created or has pending migrations.

### Usage
Add `Phoenix.Ecto.CheckRepoReady` somewhere along your application plug pipeline.

```diff
# lib/application_web/endpoint.ex
defmodule ApplicationWeb.Endpoint do
# ...
+ plug Phoenix.Ecto.CheckRepoReady, otp_app: :application_web
```

Make sure that the dependency `ecto_sql` is loaded and that you are using one of the (current) supported adapters in the repo (`myxql` or `postgres`).

(If none of those are true, the plug will just pass the connection forward without doing any checks)

### Demo

Assuming that `use Plug.Debugger` is used somewhere along with the plug pipeline/stack, it shows a nice error on the webpage.

<details>
  <summary> Error for storage not created </summary>
  <img src="https://user-images.githubusercontent.com/14015177/68427631-451e9180-0189-11ea-9d40-56872551889b.png">
  <img src="https://user-images.githubusercontent.com/14015177/68427632-451e9180-0189-11ea-9fdd-80d60ad8869f.png">
</details>

<details>
  <summary> Error for pending migrations  </summary>
  <img src="https://user-images.githubusercontent.com/14015177/68427634-45b72800-0189-11ea-8e14-e3303ca901af.png">
</details>

If the work on elixir-plug/plug#876 is loaded on the current context, it also shows an action on said error page to create the storage or run the migrations.

<details>
  <summary> Action for database not created  </summary>
  <img src="https://user-images.githubusercontent.com/14015177/68427630-451e9180-0189-11ea-843c-738ff8041ba4.png">
</details>

<details>
  <summary> Action for pending migrations  </summary>
  <img src="https://user-images.githubusercontent.com/14015177/68427629-451e9180-0189-11ea-83ec-eaf827943249.png">
</details>


<details>
  <summary> Action in action 😄  </summary>
  <img src="https://user-images.githubusercontent.com/14015177/68427943-e1e12f00-0189-11ea-9968-23cd5311133b.gif">
  <img src="https://user-images.githubusercontent.com/14015177/68429626-34701a80-018d-11ea-8335-ad754b957a9f.gif">
</details>


### Next steps
- Include this plug by default in the `phoenix` generators?

cc @josevalim @wojtekmach 