### PR TITLE
Use text for floats and decimals as the input_type

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -125,8 +125,6 @@ if Code.ensure_loaded?(Phoenix.HTML) do
 
       case type do
         :integer -> :number_input
-        :float -> :number_input
-        :decimal -> :number_input
         :boolean -> :checkbox
         :date -> :date_select
         :time -> :time_select

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -217,8 +217,8 @@ defmodule PhoenixEcto.HTMLTest do
 
     safe_form_for(changeset, fn f ->
       assert input_type(f, :integer) == :number_input
-      assert input_type(f, :float) == :number_input
-      assert input_type(f, :decimal) == :number_input
+      assert input_type(f, :float) == :text_input # https://github.com/phoenixframework/phoenix_html/issues/279
+      assert input_type(f, :decimal) == :text_input
       assert input_type(f, :string) == :text_input
       assert input_type(f, :boolean) == :checkbox
       assert input_type(f, :date) == :date_select


### PR DESCRIPTION
Fix https://github.com/phoenixframework/phoenix_html/issues/279

I also included the decimal type because it would suffer from the same issue.