### PR TITLE
Support cast_assoc `with` MFA option on inputs_for

### DIFF
--- a/test/phoenix_ecto/inputs_for_test.exs
+++ b/test/phoenix_ecto/inputs_for_test.exs
@@ -257,6 +257,29 @@ defmodule PhoenixEcto.InputsForTest do
            end) =~ input
   end
 
+  test "has many: inputs_for/4 with custom changeset" do
+    required_length = 5
+
+    changeset =
+      %User{comments: [%Comment{body: "data1"}, %Comment{body: "data2"}]}
+      |> cast(%{}, ~w()a)
+      |> cast_assoc(:comments, with: {Comment, :custom_changeset, [required_length]})
+
+    contents =
+      safe_inputs_for(
+        changeset,
+        :comments,
+        fn f ->
+          assert f.source.validations == [body: {:length, min: required_length}]
+          text_input(f, :body)
+        end
+      )
+
+    assert contents ==
+             ~s(<input id="user_comments_0_body" name="user[comments][0][body]" type="text" value="data1">) <>
+               ~s(<input id="user_comments_1_body" name="user[comments][1][body]" type="text" value="data2">)
+  end
+
   ## inputs_for embeds one
 
   test "embeds one: inputs_for/4" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -30,6 +30,14 @@ defmodule Comment do
     |> validate_required(:body)
     |> validate_length(:body, min: 3)
   end
+
+  def custom_changeset(comment, params, required_length) do
+    import Ecto.Changeset
+
+    comment
+    |> cast(params, ~w(body)a)
+    |> validate_length(:body, min: required_length)
+  end
 end
 
 defmodule User do


### PR DESCRIPTION
Now `inputs_for` uses the MFA provided via `with` option on `cast_assoc`.

Any suggestion on variable names, test options or whatever else is welcome, first PR on this project =)

Fixes #125.