### PR TITLE
Ensure form still has its id when present

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -3,10 +3,9 @@ if Code.ensure_loaded?(Phoenix.HTML) do
     def to_form(changeset, opts) do
       %{params: params, data: data} = changeset
       {name, opts} = Keyword.pop(opts, :as)
-      {id, opts} = Keyword.pop(opts, :id)
 
       name = to_string(name || form_for_name(data))
-      id = id || name
+      id = Keyword.get(opts, :id) || name
 
       %Phoenix.HTML.Form{
         source: changeset,

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -40,13 +40,19 @@ defmodule PhoenixEcto.HTMLTest do
 
     form = form_for(changeset, "/", id: "form_id")
 
-    contents =
+    form_content =
+      form
+      |> html_escape()
+      |> safe_to_string()
+
+    input_content =
       form
       |> text_input(:name)
       |> html_escape()
       |> safe_to_string()
 
-    assert contents =~ ~s(<input id="form_id_name" name="user[name]" type="text">)
+    assert form_content  =~ ~s(<form action="/" id="form_id" method="post">)
+    assert input_content =~ ~s(<input id="form_id_name" name="user[name]" type="text">)
   end
 
   test "form_for/3 without id prefix the form name in the input id" do


### PR DESCRIPTION
The last commit takes the ID from the opts so the form will never render the ID anymore. This commit fix that and ensure id will be preset with tests.