### PR TITLE
Reject non-atom field keys and show better error in input_value/4

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -102,7 +102,10 @@ if Code.ensure_loaded?(Phoenix.HTML) do
       end
     end
 
-    def input_value(%{changes: changes, data: data}, %{params: params}, field, computed \\ nil) do
+    def input_value(data, form, field, computed \\ nil)
+
+    def input_value(%{changes: changes, data: data}, %{params: params}, field, computed)
+        when is_atom(field) do
       case Map.fetch(changes, field) do
         {:ok, value} ->
           value
@@ -119,6 +122,10 @@ if Code.ensure_loaded?(Phoenix.HTML) do
               computed
           end
       end
+    end
+
+    def input_value(_data, _form, field, _computed) do
+      raise ArgumentError, "expected field to be an atom, got: #{inspect(field)}"
     end
 
     def input_type(%{types: types}, _, field) do

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -264,6 +264,22 @@ defmodule PhoenixEcto.HTMLTest do
     end)
   end
 
+  test "input value rejects non atom fields" do
+    changeset =
+      %Custom{string: "string", integer: 321, float: 321}
+      |> cast(%{float: 78.9, integer: 789}, ~w()a)
+      |> put_change(:integer, 123)
+
+    msg = ~s(expected field to be an atom, got: "string")
+
+    assert_raise ArgumentError, msg, fn ->
+      safe_form_for(changeset, fn f ->
+        input_value(f, "string")
+        ""
+      end)
+    end
+  end
+
   test "input types" do
     changeset = cast(%Custom{}, %{}, ~w()a)
 

--- a/test/phoenix_ecto/html_test.exs
+++ b/test/phoenix_ecto/html_test.exs
@@ -264,7 +264,7 @@ defmodule PhoenixEcto.HTMLTest do
     end)
   end
 
-  test "input value rejects non atom fields" do
+  test "input value rejects non-atom fields" do
     changeset =
       %Custom{string: "string", integer: 321, float: 321}
       |> cast(%{float: 78.9, integer: 789}, ~w()a)


### PR DESCRIPTION
Related to #138.