### PR TITLE
Add a note about allowing the User-Agent for Liveviews

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -103,6 +103,12 @@ defmodule Phoenix.Ecto.SQL.Sandbox do
         Phoenix.Ecto.SQL.Sandbox.allow(metadata, Ecto.Adapters.SQL.Sandbox)
       end
 
+  You will also need to explicitly allow the User-Agent header to be copied into
+  the Liveview socket connection. This can be done in `endpoint.ex`.
+
+      socket "/live", Phoenix.LiveView.Socket,
+        websocket: [connect_info: [:user_agent, session: @session_options]]
+
   This is a bit more complex than the channel code, because LiveViews not only
   are their own processes when spawned via a socket connection, but also when
   doing the static render as part of the plug pipeline. Given `get_connect_info/1`


### PR DESCRIPTION
Hello! I had almost given up on making the Ecto sandbox work with Liveviews - in an existing application - for various reasons that made me reverse-engineer how the entire sandbox implementation works, and this was the last small hurdle to overcome that was not clearly mentioned in the documentation.

The doc mentions using an `allow_ecto_sandbox/1` helper that relies on the value of the connection `User-Agent`, but that header will _not_ be available unless explicitly allowed in the endpoint configuration.

Endpoint documentation that mentions the setting - https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-common-configuration

Feel free to rephrase my change as you'd like of course 🙏 

### Screenshot post-update
![image](https://user-images.githubusercontent.com/11039634/138818844-9006f66b-7cce-486a-be99-0e6e1ad4bbc8.png)
