### PR TITLE
Update docs to align with code generated by default in Phoenix 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Then add the following to your test case (or case template):
 ```elixir
 use Hound.Helpers
 
-setup do
-  :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
-  metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
+setup tags do
+  pid = Ecto.Adapters.SQL.Sandbox.start_owner!(YourApp.Repo, shared: not tags[:async])
+  on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+  metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, pid)
   Hound.start_session(metadata: metadata)
   :ok
 end
@@ -95,9 +96,10 @@ If you don't `use Wallaby.Feature`, you can add the following to your test case 
 ```elixir
 use Wallaby.DSL
 
-setup do
-  :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
-  metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
+setup tags do
+  pid = Ecto.Adapters.SQL.Sandbox.start_owner!(YourApp.Repo, shared: not tags[:async])
+  on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+  metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, pid)
   {:ok, session} = Wallaby.start_session(metadata: metadata)
 end
 ```

--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -26,9 +26,10 @@ defmodule Phoenix.Ecto.SQL.Sandbox do
 
       use Hound.Helpers
 
-      setup do
-        :ok = Ecto.Adapters.SQL.Sandbox.checkout(YourApp.Repo)
-        metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, self())
+      setup tags do
+        pid = Ecto.Adapters.SQL.Sandbox.start_owner!(YourApp.Repo, shared: not tags[:async])
+        on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+        metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, pid)
         Hound.start_session(metadata: metadata)
         :ok
       end


### PR DESCRIPTION
I think this was changed in Phoenix generators for better LiveView test support (see https://github.com/phoenixframework/phoenix_live_view/issues/887 ), and I'm not sure if there's much difference for integration tests, probably not, but a regular `DataCase` also sets up the sandbox this way, and I just like having one way to do things