### PR TITLE
Support multiple repos on sandbox plug API

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox_session.ex
+++ b/lib/phoenix_ecto/sql/sandbox_session.ex
@@ -4,27 +4,27 @@ defmodule Phoenix.Ecto.SQL.SandboxSession do
 
   @timeout 15_000
 
-  def start_link({repo, client, opts}) do
-    GenServer.start_link(__MODULE__, [repo, client, opts])
+  def start_link({repos, client, opts}) do
+    GenServer.start_link(__MODULE__, [repos, client, opts])
   end
 
-  def init([repo, client, opts]) do
+  def init([repos, client, opts]) do
     timeout = opts[:timeout] || @timeout
     sandbox = opts[:sandbox] || Ecto.Adapters.SQL.Sandbox
 
-    :ok = checkout_connection(sandbox, repo, client)
+    :ok = checkout_connection(sandbox, repos, client)
     Process.send_after(self(), :timeout, timeout)
 
-    {:ok, %{repo: repo, client: client, sandbox: sandbox}}
+    {:ok, %{repos: repos, client: client, sandbox: sandbox}}
   end
 
   def handle_call(:checkin, _from, state) do
-    :ok = checkin_connection(state.sandbox, state.repo, state.client)
+    :ok = checkin_connection(state.sandbox, state.repos, state.client)
     {:stop, :shutdown, :ok, state}
   end
 
   def handle_info(:timeout, state) do
-    :ok = checkin_connection(state.sandbox, state.repo, state.client)
+    :ok = checkin_connection(state.sandbox, state.repos, state.client)
     {:stop, :shutdown, state}
   end
 
@@ -33,11 +33,19 @@ defmodule Phoenix.Ecto.SQL.SandboxSession do
     {:noreply, state}
   end
 
-  defp checkin_connection(sandbox, repo, client) do
-    sandbox.checkin(repo, client: client)
+  defp checkin_connection(sandbox, repos, client) do
+    for repo <- repos do
+      :ok = sandbox.checkin(repo, client: client)
+    end
+
+    :ok
   end
 
-  defp checkout_connection(sandbox, repo, client) do
-    sandbox.checkout(repo, client: client)
+  defp checkout_connection(sandbox, repos, client) do
+    for repo <- repos do
+      :ok = sandbox.checkout(repo, client: client)
+    end
+
+    :ok
   end
 end


### PR DESCRIPTION
Fix issue https://github.com/phoenixframework/phoenix_ecto/issues/154

This add the support of multiple repos to the sandbox plug API:

```elixir
plug(Phoenix.Ecto.SQL.Sandbox,
    at: "/sandbox",
    repo: [MyApp.Repo1, MyApp.Repo2],
    timeout: 60_000,
)
```

There should be no breaking changes. I reused the `repo` option and wrap it in a list if needed.

But maybe having a `repos` option would be better? While still supporting the other one.