### PR TITLE
replace mention of get_connect_info/1 -> /2

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -97,7 +97,7 @@ defmodule Phoenix.Ecto.SQL.Sandbox do
         def on_mount(:default, _params, _session, socket) do
           %{assigns: %{phoenix_ecto_sandbox: metadata}} =
             assign_new(socket, :phoenix_ecto_sandbox, fn ->
-              if connected?(socket), do: get_connect_info(socket)[:user_agent]
+              if connected?(socket), do: get_connect_info(socket, :user_agent)
             end)
 
           Phoenix.Ecto.SQL.Sandbox.allow(metadata, Ecto.Adapters.SQL.Sandbox)


### PR DESCRIPTION
`get_connect_info/1` is now deprecated in LiveView - https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#get_connect_info/1