### PR TITLE
Fix link in Phoenix.Ecto.SQL.Sandbox

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -1,7 +1,7 @@
 defmodule Phoenix.Ecto.SQL.Sandbox do
   @moduledoc """
   A plug to allow concurrent, transactional acceptance tests with
-  [`Ecto.Adapters.SQL.Sandbox`](https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.Sandbox.html).
+  [Ecto.Adapters.SQL.Sandbox](https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.Sandbox.html).
 
   ## Example
 


### PR DESCRIPTION
The old link was using backticks to style the text as code.

However, this, at least in ex_doc, seems to break the link.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/1925540/212564489-860164d1-7681-4bdd-a80f-8310523b65d7.png">

Removing the backticks removes the style, but makes the link work more conventionally.

<img width="882" alt="image" src="https://user-images.githubusercontent.com/1925540/212564431-5ca03ca8-8c4f-4aef-ade7-234b35514709.png">

Late Sunday evening PR here. If I missed a `CONTRIBUTING.md`, happy to close and reopen.
If the "broken" link is preferred, or there's a problem in ex_doc, happy to close this.

EDIT: I'm nut actually sure this is related https://github.com/elixir-lang/ex_doc/issues/1572, but it sounds like it might be.