### PR TITLE
Fix compilation warning for `Ecto.Migrator.migrations/3`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule PhoenixEcto.Mixfile do
       ],
       xref: [
         exclude: [
-          {Ecto.Migrator, :migrations, 2},
+          {Ecto.Migrator, :migrations, 3},
           {Ecto.Migrator, :migrations_path, 1},
           {Ecto.Migrator, :run, 4}
         ]


### PR DESCRIPTION
```
==> phoenix_ecto
Compiling 7 files (.ex)
warning: Ecto.Migrator.migrations/3 defined in application :ecto_sql is used by the current application but the current application does not depend on :ecto_sql. To fix this, you must do one of:

  1. If :ecto_sql is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto_sql is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto_sql, you may optionally skip this warning by adding [xref: [exclude: [Ecto.Migrator]]] to your "def project" in mix.exs

  lib/phoenix_ecto/check_repo_status.ex:99: Phoenix.Ecto.CheckRepoStatus.migrations/3
```