### PR TITLE
support arity 3 cast functions

### DIFF
--- a/test/phoenix_ecto/inputs_for_test.exs
+++ b/test/phoenix_ecto/inputs_for_test.exs
@@ -280,6 +280,26 @@ defmodule PhoenixEcto.InputsForTest do
                ~s(<input id="user_comments_1_body" name="user[comments][1][body]" type="text" value="data2">)
   end
 
+  test "has many: inputs/for/4 with custom changeset with arity 3" do
+    changeset =
+      %User{comments: [%Comment{body: "data1"}, %Comment{body: "data2"}]}
+      |> cast(%{}, ~w()a)
+      |> cast_assoc(:comments, with: &Comment.changeset_with_position/3)
+
+    contents =
+      safe_inputs_for(
+        changeset,
+        :comments,
+        fn f ->
+          number_input(f, :position)
+        end
+      )
+
+    assert contents ==
+             ~s(<input id="user_comments_0_position" name="user[comments][0][position]" type="number" value="0">) <>
+               ~s(<input id="user_comments_1_position" name="user[comments][1][position]" type="number" value="1">)
+  end
+
   ## inputs_for embeds one
 
   test "embeds one: inputs_for/4" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,6 +20,7 @@ defmodule Comment do
 
   schema "comments" do
     field :body
+    field :position, :integer
   end
 
   def changeset(comment, params) do
@@ -37,6 +38,11 @@ defmodule Comment do
     comment
     |> cast(params, ~w(body)a)
     |> validate_length(:body, min: required_length)
+  end
+
+  def changeset_with_position(comment, params, index) do
+    changeset(comment, params)
+    |> Ecto.Changeset.put_change(:position, index)
   end
 end
 


### PR DESCRIPTION
I'm trying to implement ordering a has_many association following the documentation (https://hexdocs.pm/ecto/3.10.1/Ecto.Changeset.html#cast_assoc/3-sorting-and-deleting-from-many-collections). As this lead to some problems that were fixed by https://github.com/elixir-ecto/ecto/pull/4178 (not released yet), I switched to using the current ecto main branch and modified my code according to the new documentation, adding a cast function with arity three, that receives the index as third parameter. This works fine, but not when used in a phoenix form.
When using it together with Phoenix.Component's `inputs_for/1`, it fails with an error like this:

```elixir
** (FunctionClauseError) no function clause matching in Phoenix.HTML.FormData.Ecto.Changeset.to_changeset/4

     The following arguments were given to Phoenix.HTML.FormData.Ecto.Changeset.to_changeset/4:
     
         # 1
         %Comment{__meta__: #Ecto.Schema.Metadata<:built, "comments">, id: nil, body: "data1", position: nil}
     
         # 2
         nil
     
         # 3
         Comment
     
         # 4
         &Comment.changeset_with_position/3
     
     Attempted function clauses (showing 4 out of 4):
     
         defp to_changeset(%Ecto.Changeset{} = changeset, parent_action, _module, _cast)
         defp to_changeset(%{} = data, parent_action, _module, cast) when is_function(cast, 2)
         defp to_changeset(%{} = data, parent_action, _module, {module, func, arguments} = mfa) when is_atom(module) and is_atom(func) and is_list(arguments)
         defp to_changeset(%{} = data, parent_action, _module, nil)
```

So here's a PR that tries to add support for arity three cast functions. I'm not completely sure if I implemented this right, but it seems to work with the added test and also in my Phoenix app.
If I'm not on the right track here, see this as a bug report instead :)