### PR TITLE
fix map.field notation warning on Elixir 1.17

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -50,7 +50,7 @@ if Code.ensure_loaded?(Phoenix.HTML) do
                 [validate_map!(map, field)]
 
               _ ->
-                [validate_map!(assoc_from_data(source.data, field), field) || module.__struct__]
+                [validate_map!(assoc_from_data(source.data, field), field) || module.__struct__()]
             end
 
           for changeset <- skip_replaced(changesets) do


### PR DESCRIPTION
```
warning: using map.field notation (without parentheses) to invoke function MyStruct.__struct__() is deprecated, you must add parentheses instead: remote.function()
  (phoenix_ecto 4.5.1) lib/phoenix_ecto/html.ex:53: Phoenix.HTML.FormData.Ecto.Changeset.to_form/4
```