### PR TITLE
Re-add missing directories attribute

### DIFF
--- a/lib/phoenix_ecto/check_repo_status.ex
+++ b/lib/phoenix_ecto/check_repo_status.ex
@@ -68,7 +68,7 @@ defmodule Phoenix.Ecto.CheckRepoStatus do
     rescue
       _ -> false
     else
-      true -> raise Phoenix.Ecto.PendingMigrationError, repo: repo
+      true -> raise Phoenix.Ecto.PendingMigrationError, repo: repo, directories: dirs
       false -> true
     end
   end


### PR DESCRIPTION
The `directories` attribute was recently removed from `Phoenix.Ecto.PendingMigrationError` but it shouldn't of been.

This adds it back in.