### PR TITLE
Fix map.field notation warning on Elixir 1.17

### DIFF
--- a/lib/phoenix_ecto/html.ex
+++ b/lib/phoenix_ecto/html.ex
@@ -130,7 +130,7 @@ if Code.ensure_loaded?(Phoenix.HTML) do
 
     def input_type(%{types: types}, _, field) do
       type = Map.get(types, field, :string)
-      type = if Ecto.Type.primitive?(type), do: type, else: type.type
+      type = if Ecto.Type.primitive?(type), do: type, else: type.type()
 
       case type do
         :integer -> :number_input


### PR DESCRIPTION
See https://hexdocs.pm/ecto/Ecto.Type.html#c:type/0