### PR TITLE
Add prefix option to check repo status plug

### DIFF
--- a/lib/phoenix_ecto/exceptions.ex
+++ b/lib/phoenix_ecto/exceptions.ex
@@ -8,8 +8,8 @@ defmodule Phoenix.Ecto.StorageNotCreatedError do
 end
 
 defmodule Phoenix.Ecto.PendingMigrationError do
-  @enforce_keys [:repo, :directories]
-  defexception [:repo, :directories]
+  @enforce_keys [:repo, :directories, :migration_opts]
+  defexception [:repo, :directories, :migration_opts]
 
   def message(%__MODULE__{repo: repo}) do
     "there are pending migrations for repo: #{inspect(repo)}. " <>

--- a/lib/phoenix_ecto/plug.ex
+++ b/lib/phoenix_ecto/plug.ex
@@ -30,15 +30,17 @@ unless Phoenix.Ecto.PendingMigrationError in excluded_exceptions do
   defimpl Plug.Exception, for: Phoenix.Ecto.PendingMigrationError do
     def status(_error), do: 503
 
-    def actions(%{repo: repo, directories: directories}),
+    def actions(%{repo: repo, directories: directories, migration_opts: migration_opts}),
       do: [
         %{
           label: "Run migrations for repo",
-          handler: {__MODULE__, :migrate, [repo, directories]}
+          handler: {__MODULE__, :migrate, [repo, directories, migration_opts]}
         }
       ]
 
-    def migrate(repo, directories), do: Ecto.Migrator.run(repo, directories, :up, all: true)
+    def migrate(repo, directories, migration_opts) do
+      Ecto.Migrator.run(repo, directories, :up, Keyword.merge(migration_opts, all: true))
+    end
   end
 end
 

--- a/lib/phoenix_ecto/plug.ex
+++ b/lib/phoenix_ecto/plug.ex
@@ -39,7 +39,7 @@ unless Phoenix.Ecto.PendingMigrationError in excluded_exceptions do
       ]
 
     def migrate(repo, directories, migration_opts) do
-      Ecto.Migrator.run(repo, directories, :up, Keyword.merge(migration_opts, all: true))
+      Ecto.Migrator.run(repo, directories, :up, Keyword.merge(migration_opts || [], all: true))
     end
   end
 end


### PR DESCRIPTION
When developing an app that uses [schema-based multi-tenancy](https://hexdocs.pm/ecto/multi-tenancy-with-query-prefixes.html), it would be useful to be able to configure another `CheckRepoStatus` plug for a named "dev" tenant:

```elixir
    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :myapp

    plug Phoenix.Ecto.CheckRepoStatus,
      otp_app: :myapp,
      migration_paths: &Myapp.Release.tenant_migrations_path/1,
      prefix: "tenant_acme"
```

`migration_opts` has been add to `PendingMigrationError`, so the configured `prefix` and `migration_lock` options are used when the "Run migrations for repo" action is triggered.