### PR TITLE
Allow for setting the `skip_table_creation` opt

### DIFF
--- a/lib/phoenix_ecto/check_repo_status.ex
+++ b/lib/phoenix_ecto/check_repo_status.ex
@@ -11,13 +11,14 @@ defmodule Phoenix.Ecto.CheckRepoStatus do
     * `:migration_paths` - a function that accepts a repo and returns a migration directory, or a list of migration directories, that is used to check for pending migrations
     * `:migration_lock` - the locking strategy used by the Ecto Adapter when checking for pending migrations. Set to `false` to disable migration locks.
     * `:prefix` - the prefix used to check for pending migrations.
+    * `:skip_table_creation` - Ecto will not try to create the `schema_migrations` table automatically.  This is useful if you are connecting as a DB user without create permissions
   """
 
   @behaviour Plug
 
   alias Plug.Conn
 
-  @migration_opts [:migration_lock, :prefix]
+  @migration_opts [:migration_lock, :prefix, :skip_table_creation]
   @compile {:no_warn_undefined, Ecto.Migrator}
 
   def init(opts) do


### PR DESCRIPTION
The confluence of the desire to "shift left" as much as possible along with database security requirements for a recent project lead to the discovery that currently you cannot tell ecto not to try and create the migrations table when checking migrations for the repo.

This can cause a rather misleading and not entirely accurate error message when running your local dev server as by default when checking the status of the migrations Ecto will invoke a `CREATE IF NOT EXISTS` command.  I would guess in an attempt to be as efficient as possible and not query for the table then create if it isn't there (two trips to the DB).

In our case the user we are running as locally does not have permissions to create tables in the `public` schema.

For the time being we have set things up to allow that locally.  However it would be fantastic if we could run the dev environment without needing to set that permission and still know if migrations are not current.