### PR TITLE
Update Ecto Sandbox doc

### DIFF
--- a/lib/phoenix_ecto/sql/sandbox.ex
+++ b/lib/phoenix_ecto/sql/sandbox.ex
@@ -125,6 +125,21 @@ defmodule Phoenix.Ecto.SQL.Sandbox do
         end
       end
 
+  If you have `on_mount` hooks in `live_session` defined in your `router.ex`
+  (for example, routes requiring authentication after running `mix phx.gen.auth`
+  to generate your authentication system), make sure the `MyApp.LiveAcceptance`
+  hook runs before, so following hooks have access to the Ecto Sandbox:
+
+      live_session :require_authenticated_user,
+        on_mount:
+          if(Application.compile_env(:your_app, :sql_sandbox),
+            do: [MyAppWeb.AcceptanceHook],
+            else: []
+          ) ++ [{MyAppWeb.UserAuth, :ensure_authenticated}] do
+        live "/users/settings", UserSettingsLive, :edit
+        live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
+      end
+
   ## Concurrent end-to-end tests with external clients
 
   Concurrent and transactional tests for external HTTP clients is supported,


### PR DESCRIPTION
When `on_mount` hooks on `live_session` are present, make sure they have access to the Ecto Sandbox when they access the database.