### PR TITLE
fix: disable migration lock by default on CheckRepoStatus

### DIFF
--- a/lib/phoenix_ecto/check_repo_status.ex
+++ b/lib/phoenix_ecto/check_repo_status.ex
@@ -67,7 +67,11 @@ defmodule Phoenix.Ecto.CheckRepoStatus do
       end)
 
     true = is_function(migrations_fun, 3)
-    migration_opts = Keyword.take(opts, @migration_opts)
+
+    migration_opts =
+      opts
+      |> Keyword.take(@migration_opts)
+      |> Keyword.put_new(:migration_lock, false)
 
     try do
       repo

--- a/lib/phoenix_ecto/check_repo_status.ex
+++ b/lib/phoenix_ecto/check_repo_status.ex
@@ -9,7 +9,7 @@ defmodule Phoenix.Ecto.CheckRepoStatus do
 
     * `:otp_app` - name of the application which the repos are fetched from
     * `:migration_paths` - a function that accepts a repo and returns a migration directory, or a list of migration directories, that is used to check for pending migrations
-    * `:migration_lock` - the locking strategy used by the Ecto Adapter when checking for pending migrations. Set to `false` to disable migration locks.
+    * `:migration_lock` - the locking strategy used by the Ecto Adapter when checking for pending migrations. Defaults to `false`. Set to `true` to enable migration locks.
     * `:prefix` - the prefix used to check for pending migrations.
     * `:skip_table_creation` - Ecto will not try to create the `schema_migrations` table automatically.  This is useful if you are connecting as a DB user without create permissions
   """


### PR DESCRIPTION
# Motivation

The default behavior of using locks when checking migration status caused a hard
to debug bug when `migration_lock: :pg_advisory_lock` was set on the repo config.

The bug was causing multiple slow downs on web requests due to attempts to acquire locks
on the database.

Generally locks should not be necessary for the pending migration check since we
are just reading from the migrations table and not actually running the migrations.

> [!NOTE]
> I wasn't sure if we should just deprecate the option altogether. For now that means that users can still enable `migration_lock` if they find a need for it - I'm not sure if that need really exists. Open to change that.

# Changes

Made `:migration_lock` option on `CheckRepoStatus` default to `true`.
