### PR TITLE
Replace deprecated xref config with elixirc_options

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,8 +23,8 @@ defmodule PhoenixEcto.Mixfile do
         source_ref: "v#{@version}",
         source_url: @source_url
       ],
-      xref: [
-        exclude: [
+      elixirc_options: [
+        no_warn_undefined: [
           {Ecto.Migrator, :migrations, 3},
           {Ecto.Migrator, :migrations_path, 1},
           {Ecto.Migrator, :run, 4}


### PR DESCRIPTION
Mix 1.20 deprecated the `xref: [exclude: ...]` project config key in favor of `elixirc_options: [no_warn_undefined: ...]`. Every project compiling `phoenix_ecto` as a dependency currently sees:

```
warning: "xref: [exclude: ...]" in your mix.exs file is deprecated, instead use: "elixirc_options: [no_warn_undefined: ...]"
```

This PR is a config-key rename only — same excluded MFAs, no behavior change. Verified `mix compile --force` produces no warnings after the change.